### PR TITLE
Support multiple ghq.root entries

### DIFF
--- a/autoload/ctrlp/ghq.vim
+++ b/autoload/ctrlp/ghq.vim
@@ -33,7 +33,7 @@ endfunc
 
 function! ctrlp#ghq#accept(mode, str)
   call ctrlp#exit()
-  exe 'lcd' fnamemodify(finddir(a:str, s:root), 'p')
+  exe 'lcd' get(map(filter(split(globpath(s:root, a:str), '\n'), 'isdirectory(v:val)'), 'fnamemodify(v:val, "p")'), 0, '')
 endfunction
 
 function! ctrlp#ghq#exit()


### PR DESCRIPTION
~/.gitconfig の ghq.root に記載してあるディレクトリが複数の場合、
ghq list ではリストされるものの、選択するとエラーになっていたので、選択できるようにしました。
