### PR TITLE
<F5> でのリロード時の表示更新

### DIFF
--- a/autoload/ctrlp/ghq.vim
+++ b/autoload/ctrlp/ghq.vim
@@ -77,6 +77,7 @@ function! ctrlp#ghq#reload()
     let s:root = s:get_root()
   endif
   let s:repos = s:get_repos()
+  call ctrlp#setlines()
 endfunction
 
 function! s:init()


### PR DESCRIPTION
**背景**
f7267e2a でのキャッシュを追加した際に、
キャッシュ更新時の画面の再描画をしていなかったので、`<F5>` 後に一旦CtrlPを抜けるか、`<C-f><C-b>`等をしないと、表示候補中に、更新分が出てきませんでした。

**変更内容**
リロード時に`ctrlp#setlines()`を呼ぶことで、描画を更新します。