### PR TITLE
use ghq root command

### DIFF
--- a/autoload/ctrlp/ghq.vim
+++ b/autoload/ctrlp/ghq.vim
@@ -120,11 +120,7 @@ function! s:validate(lines)
 endfunction
 
 function! s:get_root()
-  let root = join(split(system('git config --path --get-all ghq.root'), "\n"), ',')
-  if empty(root)
-    let root = expand('~/.ghq')
-  endif
-  return root
+  return join(split(system('ghq root --all'), "\n"), ',')
 endfunction
 
 function! s:get_repos()


### PR DESCRIPTION
Hi,

CtrlPGhq can't find any repositories in my laptop.
The previous behavior was trying to read from `git config` with assuming the default root is `~/.ghq`.
However, the current defualt of ghq is `~/ghq` (without period.)
I fixed this behaivor by using `ghq root --all` command.